### PR TITLE
Added a check to make sure type assertion was successful in GetSession.

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -114,7 +114,10 @@ type session struct {
 
 // GetSession returns the session stored in the request context
 func GetSession(req *http.Request) Session {
-	return context.Get(req, sessionKey).(*session)
+	if s, ok := context.Get(req, sessionKey).(*session); ok {
+		return s
+	}
+	return nil
 }
 
 func (s *session) Get(key interface{}) interface{} {


### PR DESCRIPTION
The issue I was running into was your middleware would clear the context but any middleware before the session middleware would have a runtime error if you tried to get the session.  

This was happening when I was using a recovery middleware before the session middleware, and wanted to render a template that needed something like current user.  

A simple check to see if the type assertion was successful should solve the issue.