### PR TITLE
the negroni repo moved references/imports updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Negroni middleware/handler for easy session management.
 package main
 
 import (
-  "github.com/codegangsta/negroni"
+  "github.com/urfave/negroni"
   "github.com/goincremental/negroni-sessions"
   "github.com/goincremental/negroni-sessions/cookiestore"
   "net/http"

--- a/sessions.go
+++ b/sessions.go
@@ -4,7 +4,7 @@
 //	package main
 //
 //	import (
-//		"github.com/codegangsta/negroni"
+//		"github.com/urfave/negroni"
 //		"github.com/goincremental/negroni-sessions"
 //		"net/http"
 //	)
@@ -27,9 +27,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/codegangsta/negroni"
 	"github.com/gorilla/context"
 	"github.com/gorilla/sessions"
+	"github.com/urfave/negroni"
 )
 
 type contextKey int

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/codegangsta/negroni"
 	"github.com/goincremental/negroni-sessions"
 	"github.com/goincremental/negroni-sessions/cookiestore"
+	"github.com/urfave/negroni"
 )
 
 func Test_Sessions(t *testing.T) {


### PR DESCRIPTION
The negroni repo moved from github.com/codegangsta/negroni to
github.com/urfave/negroni  The README file and import paths are updated
accordingly.